### PR TITLE
fix string checker; string with newline does not cause violation

### DIFF
--- a/src/main/scala/com/nparry/orderly/OrderlyParser.scala
+++ b/src/main/scala/com/nparry/orderly/OrderlyParser.scala
@@ -48,21 +48,25 @@ import util.parsing.input.{CharSequenceReader, Reader, StreamReader}
  * This is based on the Orderly grammar at:
  * http://github.com/lloyd/orderly/blob/master/docs.md
  */
-object OrderlyParser extends JavaTokenParsers {
 
+object OrderlyParser {
   /**
    * Parse the given string and return a JObject of the resuling schema
    */
-  def parse(s: String): JObject = parse(new CharSequenceReader(s))
+  def parse(s: String): JObject = (new OrderlyParser()).parse(new CharSequenceReader(s))
 
   /**
    * Parse the given file and return a JObject of the resuling schema
    */
   def parse(f: java.io.File): JObject = {
     val r = new java.io.FileReader(f)
-    try { parse(StreamReader(r)) } finally { r.close() }
+    try { (new OrderlyParser()).parse(StreamReader(r)) } finally { r.close() }
   }
+}
 
+// parser combinators are _not_ threadsafe; 
+// see https://issues.scala-lang.org/browse/SI-4929
+class OrderlyParser extends JavaTokenParsers {
   /**
    * Parse the given reader and return a JObject of the resuling schema
    */
@@ -76,7 +80,6 @@ object OrderlyParser extends JavaTokenParsers {
      case e:NumberFormatException => throw new InvalidOrderly(e.getMessage())
      case e:java.util.regex.PatternSyntaxException => throw new InvalidOrderly(e.getMessage())
    }
-
 
   // Some helpers to shorten the code below
 

--- a/src/test/scala/com/nparry/orderly/ReferenceImplValidatorTests.scala
+++ b/src/test/scala/com/nparry/orderly/ReferenceImplValidatorTests.scala
@@ -114,6 +114,7 @@ class ReferenceImplValidatorTests extends Specification {
     ) 
   }
 
+
   def makeOrderly(f: File): Orderly = try {
     Orderly(f)
   } catch {

--- a/src/test/scala/com/nparry/orderly/SimpleSchemaValidationTests.scala
+++ b/src/test/scala/com/nparry/orderly/SimpleSchemaValidationTests.scala
@@ -63,6 +63,11 @@ class SimpleSchemaValidationTests extends Specification {
       o.validate(Json.parse("""[ "foo", "bar" ]""")).size mustEqual 1
     }
   
+    "do string validation with strings containing newlines" in {
+      val o = Orderly("string;")
+      o.validate(JString("foo\n")).size mustEqual (0)
+    }
+  
     "do number validation" in {
       val o = Orderly("number;")
   


### PR DESCRIPTION
- JSON string with newline should not cause a schema violation
- class 'OrderlyParser' that inherits from JavaTokenParsers (a parser combinator) is not thread-safe

See the test case I added. Thanks!
