### PR TITLE
object with additionalProperties=false should not admit additional fields

### DIFF
--- a/src/main/scala/com/nparry/orderly/JsonSchema.scala
+++ b/src/main/scala/com/nparry/orderly/JsonSchema.scala
@@ -132,10 +132,11 @@ object JsonSchemaValidator {
         }
       }
 
-      def obj(name: String, f: JObject => List[Violation]): Option[List[Violation]] = {
-        value(name) match {
-          case JNothing => None
-          case o @ JObject(_) => Some(f(o))
+      def obj(name: String, f: JObject => List[Violation], defaultOpt: Option[JObject] = None): Option[List[Violation]] = {
+        (value(name), defaultOpt) match {
+          case (JNothing, None) => None
+          case (JNothing, Some(default)) => Some(f(default))
+          case (o @ JObject(_), _) => Some(f(o))
           case _ => schemaProblem("expected an object named '" + name + "'")
         }
       }
@@ -224,8 +225,13 @@ object JsonSchemaValidator {
               }) ++
               (if (BigInt(arr.length) < int("minItems", arr.length)) violation("minimum item count not met") else ok()) ++
               (if (BigInt(arr.length) > int("maxItems", arr.length)) violation("maximum item count exceeded") else ok())
-            case o @ JObject(_) =>
-              (obj("properties", { props => checkObj(o, props, path, bool("additionalProperties", true)) }) getOrElse ok())
+            case o @ JObject(_) => { 
+              val defaultOpt = value("type") match { 
+                case JString("array") => None
+                case _ => Some(JObject(List()))
+              }
+              (obj("properties", { props => checkObj(o, props, path, bool("additionalProperties", true)) }, defaultOpt) getOrElse ok())
+            }
             case JString(s) =>
               str("pattern").map { regex => {
                 if(s.matches(regex)) ok()
@@ -254,7 +260,6 @@ object JsonSchemaValidator {
 
     // validate an object against a schema
     def checkObj(instance: JObject, objTypeDef: JObject, path: List[String], additionalProp: Boolean): List[Violation] = {
-
       def ok(): List[Violation] = List()
       def violation(msg: String): List[Violation] = List(Violation(path, msg))
 

--- a/src/test/scala/com/nparry/orderly/SimpleSchemaValidationTests.scala
+++ b/src/test/scala/com/nparry/orderly/SimpleSchemaValidationTests.scala
@@ -118,6 +118,22 @@ class SimpleSchemaValidationTests extends Specification {
       o.validate(JBool(true)).size mustEqual 1
       o.validate(Json.parse("""{ "foo": "bar" }""")).size mustEqual 1
     }
+
+    "do empty object validation" in {
+      val o = Orderly("object {};")
+      
+      o.validate(Json.parse("""{ "foo": 1 }""")).size mustEqual 1  
+      o.validate(JObject(List[JField]())).size mustEqual 0
+    }
+
+    "do object union validation" in {
+      val o = Orderly("union { object { string foo; }; object {}; }")
+      
+      o.validate(Json.parse("""{ "foo": "bar" }""")).size mustEqual 0
+      o.validate(Json.parse("""{ "foo": 1 }""")).size mustEqual 2
+  
+      o.validate(JObject(List[JField]())).size mustEqual 0
+    }
   }
 }
 


### PR DESCRIPTION
Previosuly, a schema having an empty object (one with no "properties")
would admit additional fields even when additionalProperties was set to
false.

I've included a test.
