### PR TITLE
Update dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ project/boot
 target
 *.swp
 .DS_Store
+.idea/

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ organization := "com.nparry"
 
 name := "orderly"
 
-version := "1.0.9-SNAPSHOT"
+version := "1.1.0-SNAPSHOT"
 
 description := "An implementation of Orderly JSON (http://orderly-json.org/) for use on the JVM"
 
@@ -24,11 +24,13 @@ pomExtra := (
 )
 
 libraryDependencies ++= Seq(
-  "net.liftweb" %% "lift-json" % "2.6-M4",
-  "org.specs2" %% "specs2" % "2.4" % "test"
+  "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.6",
+  "net.liftweb" %% "lift-json" % "3.1.0",
+  "org.specs2" %% "specs2-core" % "3.9.5" % "test"
 )
 
-crossScalaVersions := Seq("2.10.4", "2.11.2", "2.11.8")
+crossScalaVersions := Seq("2.12.2", "2.11.11")
+scalaVersion := crossScalaVersions.value.head
 
 publishMavenStyle := true
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.16

--- a/src/main/scala/com/nparry/orderly/Json.scala
+++ b/src/main/scala/com/nparry/orderly/Json.scala
@@ -42,7 +42,7 @@ object Json {
 
   def prettyPrint(f: File): String = prettyPrint(parse(f))
   def prettyPrint(s: String): String = prettyPrint(parse(s))
-  def prettyPrint(json: JValue): String = net.liftweb.json.Printer.pretty(render(json))
+  def prettyPrint(json: JValue): String = net.liftweb.json.JsonAST.prettyRender(json)
 
   def parse(f: File): JValue = parse(new FileReader(f))
   def parse(r: Reader): JValue = try { parse(readerToString(r)) } finally { r.close() }


### PR DESCRIPTION
I have a Lift project which depends on orderly4jvm, and the 2.6.x Lift dependency is conflicting with our 3.x version. It's best practice to include the Lift edition as part of the module name for this reason. I can set this project up to support that if you like. Seeing this project hasn't had activity in roughly a year, I'm not sure if you care for supporting both 2.x and 3.x. I merely bumped the project version for now.

The Scala versions that can be supported are 2.11 and 2.12. Those have been updated accordingly.

The other version updates _shouldn't_ have any impact to consumers of this project. 

Let me know if there is anything you'd like to see in this PR for merging.